### PR TITLE
Cache all attribute names with custom casts for improved performance.

### DIFF
--- a/src/package/HasCustomCasts.php
+++ b/src/package/HasCustomCasts.php
@@ -11,6 +11,14 @@ trait HasCustomCasts
      * @var array
      */
     protected $customCastObjects = [];
+    
+    /**
+     * Caches all attribute names with custom casts for
+     * improved performance.
+     *
+     * @var array
+     */
+    protected $customCasts = null;
 
     /**
      * Boot trait
@@ -127,6 +135,10 @@ trait HasCustomCasts
      */
     public function getCustomCasts()
     {
+        if (isset($this->customCasts)) {
+            return $this->customCasts;
+        }
+        
         $customCasts = [];
         foreach ($this->casts as $attribute => $castClass) {
             if (is_subclass_of($castClass, CustomCastBase::class)) {
@@ -134,6 +146,7 @@ trait HasCustomCasts
             }
         }
 
+        $this->customCasts = $customCasts;
         return $customCasts;
     }
 }


### PR DESCRIPTION
Motivation: I have a class where just one attribute is custom-cast. Every single access to any of the other attributes would call `getCustomCasts`, which in turn invokes the autoloader in the `is_subclass_of` call for every single attribute in the `casts` array.

Caching the result of `$this->getCustomCasts()` has doubled performance for me in some cases.