### PR TITLE
Return Model on HasCustomCasts::setAttribute()

### DIFF
--- a/src/package/HasCustomCasts.php
+++ b/src/package/HasCustomCasts.php
@@ -84,7 +84,7 @@ trait HasCustomCasts
             return $this;
         }
 
-        parent::setAttribute($attribute, $value);
+        return parent::setAttribute($attribute, $value);
     }
 
     /**


### PR DESCRIPTION
Hi @vkovic,

Just a little update to return model on HasCustomCasts::setAttribute() method, like original HasAttributes::setAttribute() method.