### PR TITLE
Ability to specify human-readable cast type aliases

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Custom cast type aliases
+    |--------------------------------------------------------------------------
+    |
+    | The custom cast type aliases for the application. These are defined by 
+    | specifying the alias as the array key, and the fully qualified cast class 
+    | name as the value. For example:
+	|
+    | 'prefix_name' => PrefixNameCast::class,
+    |
+    */
+];

--- a/config/config.php
+++ b/config/config.php
@@ -9,7 +9,7 @@ return [
     | The custom cast type aliases for the application. These are defined by 
     | specifying the alias as the array key, and the fully qualified cast class 
     | name as the value. For example:
-	|
+    |
     | 'prefix_name' => PrefixNameCast::class,
     |
     */

--- a/src/HasCustomCasts.php
+++ b/src/HasCustomCasts.php
@@ -112,7 +112,7 @@ trait HasCustomCasts
             return $this->customCastObjects[$attribute];
         }
 
-        $customCastClass = $this->casts[$attribute];
+        $customCastClass = $this->guessCastClassName($this->casts[$attribute]);
         $customCastObject = new $customCastClass($this, $attribute);
 
         return $this->customCastObjects[$attribute] = $customCastObject;
@@ -131,7 +131,8 @@ trait HasCustomCasts
         }
         
         $customCasts = [];
-        foreach ($this->casts as $attribute => $castClass) {
+        foreach ($this->casts as $attribute => $type) {
+            $castClass = $this->guessCastClassName($type);
             if (is_subclass_of($castClass, CustomCastBase::class)) {
                 $customCasts[$attribute] = $castClass;
             }
@@ -139,5 +140,22 @@ trait HasCustomCasts
 
         $this->customCasts = $customCasts;
         return $customCasts;
+    }
+
+    /**
+     * Guess the cast class name for the given identifier.
+     *
+     * @param  string $identifier
+     * @return string
+     */
+    protected function guessCastClassName($identifier)
+    {
+        $class = str_replace(' ', '', ucwords(str_replace('_', ' ', $identifier))) . 'Cast';
+        $classDirname = str_replace('/', '\\', dirname(str_replace('\\', '/', $class)));
+        $fqcn = $classDirname . '\\Casts\\' . $class;
+        
+        return class_exists($fqcn)
+            ? $fqcn
+            : $identifier;
     }
 }

--- a/src/HasCustomCasts.php
+++ b/src/HasCustomCasts.php
@@ -112,7 +112,7 @@ trait HasCustomCasts
             return $this->customCastObjects[$attribute];
         }
 
-        $customCastClass = $this->guessCastClassName($this->casts[$attribute]);
+        $customCastClass = $this->getCastClass($this->casts[$attribute]);
         $customCastObject = new $customCastClass($this, $attribute);
 
         return $this->customCastObjects[$attribute] = $customCastObject;
@@ -132,7 +132,7 @@ trait HasCustomCasts
         
         $customCasts = [];
         foreach ($this->casts as $attribute => $type) {
-            $castClass = $this->guessCastClassName($type);
+            $castClass = $this->getCastClass($type);
             if (is_subclass_of($castClass, CustomCastBase::class)) {
                 $customCasts[$attribute] = $castClass;
             }
@@ -143,19 +143,17 @@ trait HasCustomCasts
     }
 
     /**
-     * Guess the cast class name for the given identifier.
+     * Get the cast class name for the given identifier.
      *
      * @param  string $identifier
      * @return string
      */
-    protected function guessCastClassName($identifier)
+    protected function getCastClass($identifier)
     {
-        $class = str_replace(' ', '', ucwords(str_replace('_', ' ', $identifier))) . 'Cast';
+        $casts = config('custom_casts');
 
-        $fqcn = app()->getNamespace() . 'Casts\\' . $class;
-        
-        return class_exists($fqcn)
-            ? $fqcn
+        return is_array($casts) && isset($casts[$identifier])
+            ? $casts[$identifier]
             : $identifier;
     }
 }

--- a/src/HasCustomCasts.php
+++ b/src/HasCustomCasts.php
@@ -151,8 +151,8 @@ trait HasCustomCasts
     protected function guessCastClassName($identifier)
     {
         $class = str_replace(' ', '', ucwords(str_replace('_', ' ', $identifier))) . 'Cast';
-        $classDirname = str_replace('/', '\\', dirname(str_replace('\\', '/', $class)));
-        $fqcn = $classDirname . '\\Casts\\' . $class;
+
+        $fqcn = app()->getNamespace() . 'Casts\\' . $class;
         
         return class_exists($fqcn)
             ? $fqcn

--- a/src/LaravelCustomCastsServiceProvider.php
+++ b/src/LaravelCustomCastsServiceProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Vkovic\LaravelCustomCasts;
+
+use Illuminate\Support\ServiceProvider;
+
+class LaravelCustomCastsServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap the application services.
+     */
+    public function boot()
+    {
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__ . '/../config/config.php' => config_path('custom_casts.php'),
+            ], 'config');
+        }
+    }
+
+    /**
+     * Register the application services.
+     */
+    public function register()
+    {
+        $this->mergeConfigFrom(__DIR__ . '/../config/config.php', 'custom_casts');
+    }
+}

--- a/tests/Support/Models/Image.php
+++ b/tests/Support/Models/Image.php
@@ -8,27 +8,14 @@ use Vkovic\LaravelCustomCasts\Test\Support\CustomCasts\Base64ImageCast;
 
 class Image extends Model
 {
-    use HasCustomCasts {
-    	guessCastClassName as traitGuessCastClassName;
-    }
+    use HasCustomCasts;
 
     protected $guarded = [];
     protected $table = 'images';
 
     protected $casts = [
         'data' => 'array',
-        // The same underlying cast expressed in two different ways
         'image' => 'base64_image',
-        'thumb' => Base64ImageCast::class,
+        'thumb' => 'base64_image',
     ];
-
-    protected function guessCastClassName($identifier)
-    {
-    	$class = str_replace(' ', '', ucwords(str_replace('_', ' ', $identifier))) . 'Cast';
-    	$fqcn = 'Vkovic\\LaravelCustomCasts\\Test\\Support\\CustomCasts\\'  . $class;
-
-    	return class_exists($fqcn)
-			? $fqcn
-			: $identifier;
-    }
 }

--- a/tests/Support/Models/Image.php
+++ b/tests/Support/Models/Image.php
@@ -8,14 +8,27 @@ use Vkovic\LaravelCustomCasts\Test\Support\CustomCasts\Base64ImageCast;
 
 class Image extends Model
 {
-    use HasCustomCasts;
+    use HasCustomCasts {
+    	guessCastClassName as traitGuessCastClassName;
+    }
 
     protected $guarded = [];
     protected $table = 'images';
 
     protected $casts = [
         'data' => 'array',
-        'image' => Base64ImageCast::class,
+        // The same underlying cast expressed in two different ways
+        'image' => 'base64_image',
         'thumb' => Base64ImageCast::class,
     ];
+
+    protected function guessCastClassName($identifier)
+    {
+    	$class = str_replace(' ', '', ucwords(str_replace('_', ' ', $identifier))) . 'Cast';
+    	$fqcn = 'Vkovic\\LaravelCustomCasts\\Test\\Support\\CustomCasts\\'  . $class;
+
+    	return class_exists($fqcn)
+			? $fqcn
+			: $identifier;
+    }
 }

--- a/tests/Support/Models/ImageWithPrefixNameCast.php
+++ b/tests/Support/Models/ImageWithPrefixNameCast.php
@@ -7,6 +7,6 @@ use Vkovic\LaravelCustomCasts\Test\Support\CustomCasts\PrefixNameCast;
 class ImageWithPrefixNameCast extends Image
 {
     protected $casts = [
-        'image' => PrefixNameCast::class
+        'image' => 'prefix_name',
     ];
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,8 @@ namespace Vkovic\LaravelCustomCasts\Test;
 use Illuminate\Foundation\Application;
 use Orchestra\Database\ConsoleServiceProvider;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use Vkovic\LaravelCustomCasts\Test\Support\CustomCasts\PrefixNameCast;
+use Vkovic\LaravelCustomCasts\Test\Support\CustomCasts\Base64ImageCast;
 
 class TestCase extends OrchestraTestCase
 {
@@ -49,6 +51,9 @@ class TestCase extends OrchestraTestCase
             'driver' => 'sqlite',
             'database' => ':memory:',
         ]);
+
+        $app['config']->set('custom_casts.base64_image', Base64ImageCast::class);
+        $app['config']->set('custom_casts.prefix_name', PrefixNameCast::class);
     }
 
     /**


### PR DESCRIPTION
@vkovic Created a draft PR to show the general idea I had.

The current logic assumes that the cast classes are located in the `/app/Casts` directory, but to override this developers would have to override the `HasCustomCasts` trait itself before applying it to the models. Curious if you see another way to approach this?

P.S. I confirmed that the unit tests are passing, but haven't yet tested that it correctly locates files in the default `app/Casts` directory.

Original issue: #10 