### PR TITLE
Listener for each attribute

### DIFF
--- a/src/HasCustomCasts.php
+++ b/src/HasCustomCasts.php
@@ -181,6 +181,6 @@ trait HasCustomCasts
      */
     protected function getCastClass($castType)
     {
-        return config('custom_casts')[$castType] ?? $castType;
+        return config("custom_casts.$castType", $castType);
     }
 }

--- a/src/HasCustomCasts.php
+++ b/src/HasCustomCasts.php
@@ -61,7 +61,7 @@ trait HasCustomCasts
         }
 
         if ($this->isCustomCasts($attribute)) {
-            $this->attributes[$attribute] = $this->getCustomCastObject($attribute)->setAttribute($value);
+            $this->attributes[$attribute] = $this->setCustomCast($attribute, $value);
 
             return $this;
         }
@@ -108,10 +108,36 @@ trait HasCustomCasts
     protected function castAttribute($attribute, $value)
     {
         if ($this->isCustomCasts($attribute)) {
-            return $this->getCustomCastObject($attribute)->castAttribute($value);
+            return $this->castCustomCast($attribute, $value);
         }
 
         return parent::castAttribute($attribute, $value);
+    }
+
+    /**
+     * Cast attribute (from db value to our custom format)
+     *
+     * @param $attribute
+     * @param $value
+     *
+     * @return mixed|null
+     */
+    protected function castCustomCast($attribute, $value)
+    {
+        return $this->getCustomCastObject($attribute)->castAttribute($value);
+    }
+
+    /**
+     * Cast attribute (from db value to our custom format)
+     *
+     * @param $attribute
+     * @param $value
+     *
+     * @return mixed|null
+     */
+    protected function setCustomCast($attribute, $value)
+    {
+        return $this->getCustomCastObject($attribute)->setAttribute($value);
     }
 
     /**

--- a/src/HasCustomCasts.php
+++ b/src/HasCustomCasts.php
@@ -51,7 +51,7 @@ trait HasCustomCasts
      * @param string $event
      * @param string $attribute
      */
-    private static function registerListenerForAttribute($event, $attribute): void
+    protected static function registerListenerForAttribute($event, $attribute): void
     {
         static::registerModelEvent(
             $event,

--- a/tests/Support/CustomCasts/EventHandlingCast.php
+++ b/tests/Support/CustomCasts/EventHandlingCast.php
@@ -21,6 +21,11 @@ class EventHandlingCast extends CustomCastBase
         return $value;
     }
 
+    public function booted()
+    {
+        $this->eventsReceived[] = 'booted';
+    }
+    
     public function retrieved()
     {
         $this->eventsReceived[] = 'retrieved';


### PR DESCRIPTION
Take a look at this idea for events. It will register an event listener for each custom casts attribute only if the method for that listener is defined. This eliminates overhead when you do not use events in your custom casts.
