### PR TITLE
Allow this repo to be used without Laravel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# What is different about this fork
+This fork does not require you to make use of the `config()` function. This is useful if you are using eloquent + custom casts without Laravel
+
 # Laravel Custom Casts
 
 [![Build](https://api.travis-ci.org/vkovic/laravel-custom-casts.svg?branch=master)](https://travis-ci.org/vkovic/laravel-custom-casts)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# What is different about this fork
-This fork does not require you to make use of the `config()` function. This is useful if you are using eloquent + custom casts without Laravel
-
 # Laravel Custom Casts
 
 [![Build](https://api.travis-ci.org/vkovic/laravel-custom-casts.svg?branch=master)](https://travis-ci.org/vkovic/laravel-custom-casts)

--- a/src/CustomCastBase.php
+++ b/src/CustomCastBase.php
@@ -8,8 +8,6 @@ abstract class CustomCastBase
 {
     /**
      * Model
-     *
-     * @var Model
      */
     protected $model;
 
@@ -20,7 +18,7 @@ abstract class CustomCastBase
      */
     protected $attribute;
 
-    public function __construct(Model $model, $attribute)
+    public function __construct($model, $attribute)
     {
         $this->model = $model;
         $this->attribute = $attribute;

--- a/src/HasCustomCasts.php
+++ b/src/HasCustomCasts.php
@@ -204,6 +204,10 @@ trait HasCustomCasts
      */
     protected function getCastClass($castType)
     {
-        return config("custom_casts.$castType", $castType);
+        if(function_exists('config')) {
+            return config("custom_casts.$castType", $castType);
+        } else {
+            return $castType;
+        }
     }
 }


### PR DESCRIPTION
Currently this repo depends on the presence of `config()`. With this simple change it can be used in projects that use `illuminate/database` without Laravel.