### PR TITLE
Encourage using native custom casts in Laravel 7+

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ The package is compatible with **Laravel** versions `5.5`, `5.6`, `5.7`, `5.8` a
 
 and **Lumen** versions `5.5`, `5.6`, `5.7`, `5.8`.
 
+Laravel 7+ has native support for [Custom Casts](https://laravel.com/docs/7.x/eloquent-mutators#custom-casts) that are incompatible with this library.
+
 Minimum supported version of PHP is `7.1`. 
 PHP `8` is also supported.
 


### PR DESCRIPTION
Thank you for clarifying in #21 how this library is different from Laravel 7's native cast support.

The README should document that Laravel 7+ has native support for [Custom Casts](https://laravel.com/docs/7.x/eloquent-mutators#custom-casts).